### PR TITLE
Migrate to PostgreSQL and upgrade to Java 25 / Spring Boot 4

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v4
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7
-      with:
-        arguments: build
+      run: ./gradlew build

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ It is a healthcare service who coordinate booking appointments, enabling clients
 Prerequisites
 -------------
 
-* Java JDK 17
+* Java JDK 25
 * Gradle
 * Docker / Docker Compose
 
 #### Resources
 * Axon
-* Elasticsearch
+* PostgreSQL

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,17 @@
 plugins {
-    id 'org.springframework.boot' version '3.1.2'
-    id 'io.spring.dependency-management' version '1.1.2'
+    id 'org.springframework.boot' version '4.0.3'
+    id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
 }
 
 group = 'br.ead.axon'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
 
 configurations {
     compileOnly {
@@ -19,16 +24,17 @@ repositories {
 }
 
 dependencies {
+    def axonVersion = '4.13.0'
+
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation ('org.axonframework:axon-spring-boot-starter:4.8.1') {
+    implementation ("org.axonframework:axon-spring-boot-starter:${axonVersion}") {
         exclude group: 'org.axonframework', module: 'axon-server-connector'
     }
 
-    implementation 'org.hibernate:hibernate-validator:7.0.1.Final'
-    implementation 'mysql:mysql-connector-java:8.0.26'
+    runtimeOnly 'org.postgresql:postgresql'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
@@ -41,12 +47,12 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
 
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 
-    testImplementation 'org.axonframework:axon-test:4.5.9'
+    testImplementation ("org.axonframework:axon-test:${axonVersion}")
 
 }
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,22 +1,17 @@
-version: '3.9'
 services:
 
   appointment-service-db:
-    image: mysql:8.0.23
-    platform: linux/amd64
+    image: postgres:18.2
     container_name: appointment-service-db
     volumes:
-      - appointment-service-db-data:/var/lib/mysql
+      - appointment-service-pg18-data:/var/lib/postgresql
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-      MYSQL_ROOT_PASSWORD: 'root'
-      MYSQL_USER: 'appointment'
-      MYSQL_PASSWORD: 'appointment'
-      MYSQL_DATABASE: 'appointment_data'
-    command: --character-set-server=utf8 --collation-server=utf8_unicode_ci --init-connect='SET collation_connection = utf8_unicode_ci;'
+      POSTGRES_USER: 'appointment'
+      POSTGRES_PASSWORD: 'appointment'
+      POSTGRES_DB: 'appointment_data'
     ports:
-      - "3306:3306"
+      - "5432:5432"
 
 volumes:
-  appointment-service-db-data:
+  appointment-service-pg18-data:
     driver: local

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/br/ead/axon/model/entities/Appointment.java
+++ b/src/main/java/br/ead/axon/model/entities/Appointment.java
@@ -7,8 +7,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
@@ -30,7 +28,6 @@ import java.util.Set;
 public final class Appointment {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     private String appointmentId;
 
     @Column(name = "start_at")

--- a/src/main/java/br/ead/axon/services/AppointmentEventHandler.java
+++ b/src/main/java/br/ead/axon/services/AppointmentEventHandler.java
@@ -8,6 +8,7 @@ import br.ead.axon.model.querry.FindAllAppointmentQuery;
 import br.ead.axon.model.entities.Appointment;
 import br.ead.axon.model.entities.AppointmentStatus;
 import br.ead.axon.repositories.AppointmentRepository;
+import jakarta.persistence.EntityManager;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.axonframework.eventhandling.EventHandler;
@@ -22,6 +23,7 @@ import java.util.List;
 public class AppointmentEventHandler {
 
     private final AppointmentRepository appointmentRepository;
+    private final EntityManager entityManager;
 
     @EventHandler
     public void on(AppointmentBookedEvent event) {
@@ -32,9 +34,9 @@ public class AppointmentEventHandler {
                 event.getLocation(),
                 event.getParticipants(),
                 AppointmentStatus.CREATED);
-        Appointment persisted = appointmentRepository.save(appointment);
+        entityManager.persist(appointment);
 
-        log.info("Persisted the Appointment [{}]", persisted);
+        log.info("Persisted the Appointment [{}]", appointment);
     }
 
     @EventHandler

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,11 @@
 spring:
   jpa:
-    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
 
   datasource:
-    url: jdbc:mysql://localhost:3306/appointment_data
+    url: jdbc:postgresql://localhost:5432/appointment_data
     username: appointment
     password: appointment
 
   jackson:
     property-naming-strategy: SNAKE_CASE
-    serialization:
-      write-durations-as-timestamps: false

--- a/src/test/java/br/ead/axon/SpringBootIntegrationTest.java
+++ b/src/test/java/br/ead/axon/SpringBootIntegrationTest.java
@@ -1,7 +1,7 @@
 package br.ead.axon;
 
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/java/br/ead/axon/controllers/AppointmentsControllerTest.java
+++ b/src/test/java/br/ead/axon/controllers/AppointmentsControllerTest.java
@@ -17,7 +17,6 @@ import br.ead.axon.model.api.ClinicianParticipant;
 import br.ead.axon.model.api.DigitalLocation;
 import br.ead.axon.model.api.PatientParticipant;
 import br.ead.axon.model.requests.BookAppointmentRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.Set;
@@ -27,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
 
 class AppointmentsControllerTest extends SpringBootIntegrationTest {
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,14 +1,12 @@
 spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
-    serialization:
-      write-durations-as-timestamps: false
 
   jpa:
     show-sql: true
     hibernate:
       ddl-auto: update
-    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
 
   docker:
     compose:


### PR DESCRIPTION
## Summary

This PR migrates the project from MySQL to PostgreSQL and modernizes the build/runtime stack to run on the current Java toolchain.

## What Changed

- Migrated persistence setup from **MySQL** to **PostgreSQL**
- Updated Docker Compose database service and datasource configuration
- Upgraded runtime/build stack:
  - **Java 25**
  - **Spring Boot 4.0.3**
  - **Gradle Wrapper 9.3.1**
  - **Axon 4.13.0** (runtime + test alignment)
- Updated tests for Spring Boot 4 / Jackson 3 API changes
- Updated GitHub Actions workflow to build with **JDK 25**
- Updated README prerequisites/resources

## Technical Notes

- `spring-boot-starter-test` in Spring Boot 4 no longer includes MVC test support by default, so `spring-boot-starter-webmvc-test` was added.
- Jackson 3 package changes required test import updates (`tools.jackson.databind.ObjectMapper`).
- Removed obsolete Jackson config that no longer binds under Boot 4/Jackson 3 (`write-durations-as-timestamps`).
- Fixed a projection persistence issue exposed by Hibernate 7 / Spring Data JPA 4:
  - The `Appointment` read-model uses an assigned ID.
  - Instead of adding entity lifecycle state (`Persistable.isNew()`), the projection create path now uses `EntityManager.persist(...)` explicitly.

## PostgreSQL / Docker Notes

- Docker Compose now runs PostgreSQL on port `5432` with the `appointment` user/database.
- For PostgreSQL 18 images, the volume mount was adjusted to `/var/lib/postgresql` (required by the newer image layout).
- Compose uses `postgres:18.2` because the `postgres:18.3` Docker image tag was not available for `linux/arm64/v8` at the time of migration (even though PostgreSQL 18.3 had been officially released).

## Validation

- `./gradlew build` passes locally on **Java 25**
- Integration tests run against Docker Compose PostgreSQL

## Impact

This is a breaking change for local development environments:
- Java 25 is now required
- Database backend is PostgreSQL (not MySQL)
- Local DB port changes from `3306` to `5432`
